### PR TITLE
Storage instance duplication fixed.

### DIFF
--- a/themes/training-theme-default/styleguide/training/hud/Hud.hbs
+++ b/themes/training-theme-default/styleguide/training/hud/Hud.hbs
@@ -33,7 +33,7 @@
         {{#with href}}
             <div class="Hud-button">
                 {{!-- Format allows us to access the properties we want to stay as constants which are set in our Hud.properties file --}}
-                <a href="/storage/{{this}}" target="_blank" download>{{format "downloadText"}}</a>
+                <a href="{{this}}" target="_blank" download>{{format "downloadText"}}</a>
             </div>
         {{/with}}
     </main>


### PR DESCRIPTION
`Error: File Not Found`

![Screen Shot 2021-06-16 at 3 04 44 PM](https://user-images.githubusercontent.com/85507352/122293934-27fd8900-cebd-11eb-93bb-3fa5a96c9aaf.png)

Frontend is adding an extra "/storage/"  in href path which is causing "File not found error".

Backend is already passing the URL with "/storage/**" as URL ,  Fixed extra "storage" path("/storage/storage/**") in frontend.


